### PR TITLE
bugfix: add UILaunchStoryboardName entry to Info.plist

### DIFF
--- a/layout/Applications/TrollSpeed.app/Info.plist
+++ b/layout/Applications/TrollSpeed.app/Info.plist
@@ -52,6 +52,8 @@
 	<string>UIBackgroundStyleDarkBlur</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
adding “UILaunchStoryboardName” fixes the boxed issue when installing the ipa (on iOS 14 at least) 
![5DD2432D-6899-4DC7-81CC-073CA90FB09D](https://github.com/Lessica/TrollSpeed/assets/7036054/81c2542e-acd2-4412-b645-ae5ad6003907)
