### PR TITLE
misc feature: disable control + notification center while in the app

### DIFF
--- a/supports/entitlements.plist
+++ b/supports/entitlements.plist
@@ -34,6 +34,10 @@
 	<true/>
 	<key>com.apple.springboard.appbackgroundstyle</key>
 	<true/>
+	<key>com.apple.springboard.disallowControlCenter</key>
+	<true/>
+	<key>com.apple.springboard.disallowNotificationCenter</key>
+	<true/>
 	<key>file-read-data</key>
 	<true/>
 	<key>platform-application</key>


### PR DESCRIPTION
very misc feature, but prevents accidentally entering notification/control center while adjusting the hud window level (only within in the app)